### PR TITLE
feat: refactor jump mode to list mode with custom action support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # buffer-sticks.nvim
 
-A neovim plugin that displays a vertical indicator showing open buffers.
+A neovim plugin that displays a vertical indicator showing open buffers and doubles as a customizable buffer picker.
 
 ![Demo](assets/demo.png)
 
@@ -12,7 +12,8 @@ Jump mode for quick buffer navigation:
 
 - Visual representation of open buffers
 - Highlights the currently active buffer
-- Jump mode for quick buffer navigation by typing characters
+- List mode for quick buffer navigation or closing by typing characters
+- Custom action functions for building buffer pickers
 - Configurable positioning and appearance
 - Transparent background support
 - Persists highlight configuration across colorscheme changes
@@ -89,11 +90,11 @@ require("buffer-sticks").setup({
   alternate_modified_char = " ─", -- Character for alternate modified buffer (unsaved changes)
   transparent = true,           -- Remove background color (shows terminal/editor background)
   auto_hide = true,                -- Auto-hide when cursor is over float (default: true)
-  label = { show = "jump" },       -- Label display: "always", "jump", or "never"
-  jump = {
-    show = { "filename", "space", "label" }, -- Jump mode display options
+  label = { show = "list" },       -- Label display: "always", "list", or "never"
+  list = {
+    show = { "filename", "space", "label" }, -- List mode display options
     keys = {
-      close_buffer = "<C-q>",      -- Key to close buffer in jump mode
+      close_buffer = "<C-q>",      -- Key to close buffer in list mode
     },
   }
   -- winblend = 100,                    -- Window blend level (0-100, 0=opaque, 100=fully blended)
@@ -126,27 +127,61 @@ BufferSticks.show()
 -- Hide
 BufferSticks.hide()
 
--- Enter jump mode to navigate by typing
+-- Enter list mode to navigate buffers
+BufferSticks.list({ action = "open" })
+
+-- Enter list mode to close buffers
+BufferSticks.list({ action = "close" })
+
+-- Alias for jumping to buffers (same as list with action="open")
 BufferSticks.jump()
+
+-- Alias for closing buffers (same as list with action="close")
+BufferSticks.close()
+
+-- Custom action function (buffer picker)
+BufferSticks.list({
+  action = function(buffer, leave)
+    -- Do something with buffer.id, buffer.name, etc.
+    print("Selected buffer: " .. buffer.name)
+    leave() -- Call this to leave list mode
+  end
+})
 ```
 
-## Jump Mode
+## List Mode
 
-Jump mode allows you to quickly navigate to buffers by typing their first character(s):
+List mode allows you to quickly navigate to or close buffers by typing their first character(s):
 
-1. Call `BufferSticks.jump()`
+**Navigate to buffers:**
+1. Call `BufferSticks.list({ action = "open" })` or `BufferSticks.jump()`
 2. Type the first character of the buffer you want to jump to
 3. If multiple buffers match, continue typing more characters
-4. Press `Ctrl-Q` (configurable) to close the current buffer
+4. Press `Ctrl-Q` (configurable) to close the current active buffer
 5. Press `Esc` or `Ctrl-C` to cancel
+
+**Close buffers:**
+1. Call `BufferSticks.list({ action = "close" })` or `BufferSticks.close()`
+2. Type the first character of the buffer you want to close
+3. If multiple buffers match, continue typing more characters
+4. Press `Ctrl-Q` (configurable) to close the current active buffer
+5. Press `Esc` or `Ctrl-C` to cancel
+
+**Custom action function (buffer picker):**
+1. Call `BufferSticks.list({ action = function(buffer, leave) ... end })`
+2. Type the first character to select a buffer
+3. When a match is found, your function is called with:
+   - `buffer`: The selected buffer info (with `id`, `name`, `label`, etc.)
+   - `leave`: Function to call when you're done to exit list mode
+4. You control when to exit by calling `leave()`
 
 **Label Display Options:**
 - `label = { show = "always" }` - Always show buffer name labels
-- `label = { show = "jump" }` - Only show labels when in jump mode (default)
+- `label = { show = "list" }` - Only show labels when in list mode (default)
 - `label = { show = "never" }` - Never show labels
 
-**Jump Mode Display Options:**
-- **Default**: `jump = { show = { "filename", "space", "label" } }`
+**List Mode Display Options:**
+- **Default**: `list = { show = { "filename", "space", "label" } }`
 
 **Available elements:**
 - `"filename"` - Full filename
@@ -190,4 +225,6 @@ highlights = {
 - `toggle()` - Toggle buffer sticks visibility
 - `show()` - Show buffer sticks
 - `hide()` - Hide buffer sticks
-- `jump()` - Enter jump mode for quick buffer navigation
+- `list(opts)` - Enter list mode with action ("open", "close", or custom function)
+- `jump()` - Enter list mode for quick buffer navigation (alias for `list({ action = "open" })`)
+- `close()` - Enter list mode to close buffers (alias for `list({ action = "close" })`)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,12 @@ require("buffer-sticks").setup({
   transparent = true,           -- Remove background color (shows terminal/editor background)
   auto_hide = true,                -- Auto-hide when cursor is over float (default: true)
   label = { show = "jump" },       -- Label display: "always", "jump", or "never"
-  jump = { show = { "filename", "space", "label" } }, -- Jump mode display options
+  jump = {
+    show = { "filename", "space", "label" }, -- Jump mode display options
+    keys = {
+      close_buffer = "<C-q>",      -- Key to close buffer in jump mode
+    },
+  }
   -- winblend = 100,                    -- Window blend level (0-100, 0=opaque, 100=fully blended)
   -- filter = {
   --   filetypes = { "help", "qf" },    -- Exclude by filetype (also: "NvimTree", "neo-tree", "Trouble")
@@ -132,7 +137,8 @@ Jump mode allows you to quickly navigate to buffers by typing their first charac
 1. Call `BufferSticks.jump()`
 2. Type the first character of the buffer you want to jump to
 3. If multiple buffers match, continue typing more characters
-4. Press `Esc` or `Ctrl-C` to cancel
+4. Press `Ctrl-Q` (configurable) to close the current buffer
+5. Press `Esc` or `Ctrl-C` to cancel
 
 **Label Display Options:**
 - `label = { show = "always" }` - Always show buffer name labels

--- a/lua/buffer-sticks/init.lua
+++ b/lua/buffer-sticks/init.lua
@@ -13,12 +13,16 @@ local M = {}
 ---@field visible boolean Whether the buffer sticks are currently visible
 ---@field cached_buffer_ids integer[] Cached list of buffer IDs for label generation
 ---@field cached_labels table<integer, string> Map of buffer ID to generated label
+---@field list_mode boolean Whether list mode is active
+---@field list_input string Current input in list mode
+---@field list_action string Current action in list mode ("open" or "close")
 local state = {
 	win = -1,
 	buf = -1,
 	visible = false,
-	jump_mode = false,
-	jump_input = "",
+	list_mode = false,
+	list_input = "",
+	list_action = "open",
 	cached_buffer_ids = {},
 	cached_labels = {},
 	auto_hidden = false,
@@ -37,15 +41,15 @@ local state = {
 ---@field bottom integer Bottom padding inside the window
 ---@field left integer Left padding inside the window
 
----@class BufferSticksJumpKeys
----@field close_buffer string Key combination to close buffer in jump mode
+---@class BufferSticksListKeys
+---@field close_buffer string Key combination to close buffer in list mode
 
----@class BufferSticksJump
----@field show string[] What to show in jump mode: "filename", "space", "label", "stick"
----@field keys BufferSticksJumpKeys Key mappings for jump mode
+---@class BufferSticksList
+---@field show string[] What to show in list mode: "filename", "space", "label", "stick"
+---@field keys BufferSticksListKeys Key mappings for list mode
 
 ---@class BufferSticksLabel
----@field show "always"|"jump"|"never" When to show buffer name characters
+---@field show "always"|"list"|"never" When to show buffer name characters
 
 ---@class BufferSticksFilter
 ---@field filetypes? string[] List of filetypes to exclude from buffer sticks
@@ -65,7 +69,7 @@ local state = {
 ---@field winblend? number Window blend level (0-100)
 ---@field auto_hide boolean Auto-hide when cursor is over float
 ---@field label? BufferSticksLabel Label display configuration
----@field jump? BufferSticksJump Jump mode configuration
+---@field list? BufferSticksList List mode configuration
 ---@field filter? BufferSticksFilter Filter configuration for excluding buffers
 ---@field highlights table<string, BufferSticksHighlights> Highlight groups for active/inactive/label states
 local config = {
@@ -79,8 +83,8 @@ local config = {
 	alternate_modified_char = "*─",
 	transparent = true,
 	auto_hide = true,
-	label = { show = "jump" },
-	jump = {
+	label = { show = "list" },
+	list = {
 		show = { "filename", "space", "label" },
 		keys = {
 			close_buffer = "<C-q>",
@@ -443,12 +447,12 @@ local function calculate_required_width()
 	local max_width = 1
 
 	-- Calculate based on current display mode
-	if state.jump_mode and config.jump and config.jump.show then
-		-- Jump mode: calculate based on jump.show config
-		local show_filename = vim.list_contains(config.jump.show, "filename")
-		local show_space = vim.list_contains(config.jump.show, "space")
-		local show_label = vim.list_contains(config.jump.show, "label")
-		local show_stick = vim.list_contains(config.jump.show, "stick")
+	if state.list_mode and config.list and config.list.show then
+		-- List mode: calculate based on list.show config
+		local show_filename = vim.list_contains(config.list.show, "filename")
+		local show_space = vim.list_contains(config.list.show, "space")
+		local show_label = vim.list_contains(config.list.show, "label")
+		local show_stick = vim.list_contains(config.list.show, "stick")
 
 		local total_width = 0
 
@@ -566,7 +570,7 @@ end
 ---Handle cursor movement for auto-hide behavior
 local function handle_cursor_move()
 	-- Only handle auto-hide if auto_hide is enabled and we're visible (or auto-hidden)
-	if not config.auto_hide or state.jump_mode then
+	if not config.auto_hide or state.list_mode then
 		return
 	end
 
@@ -681,16 +685,16 @@ local function render_buffers()
 		-- Determine if we should show characters based on config and state
 		if config.label and config.label.show == "always" then
 			should_show_char = true
-		elseif config.label and config.label.show == "jump" and state.jump_mode then
+		elseif config.label and config.label.show == "list" and state.list_mode then
 			should_show_char = true
 		end
 
-		-- In jump mode, use jump.show configuration
-		if state.jump_mode and config.jump and config.jump.show then
-			local show_filename = vim.list_contains(config.jump.show, "filename")
-			local show_space = vim.list_contains(config.jump.show, "space")
-			local show_label = vim.list_contains(config.jump.show, "label")
-			local show_stick = vim.list_contains(config.jump.show, "stick")
+		-- In list mode, use list.show configuration
+		if state.list_mode and config.list and config.list.show then
+			local show_filename = vim.list_contains(config.list.show, "filename")
+			local show_space = vim.list_contains(config.list.show, "space")
+			local show_label = vim.list_contains(config.list.show, "label")
+			local show_stick = vim.list_contains(config.list.show, "stick")
 
 			local parts = {}
 
@@ -785,12 +789,12 @@ local function render_buffers()
 		local line_idx = i - 1 + config.padding.top -- Account for top padding
 		local line_content = final_lines[i + config.padding.top] -- Access content from final padded lines
 
-		-- In jump mode, apply specific highlighting for different parts
-		if state.jump_mode and config.jump and config.jump.show then
-			local show_filename = vim.list_contains(config.jump.show, "filename")
-			local show_space = vim.list_contains(config.jump.show, "space")
-			local show_label = vim.list_contains(config.jump.show, "label")
-			local show_stick = vim.list_contains(config.jump.show, "stick")
+		-- In list mode, apply specific highlighting for different parts
+		if state.list_mode and config.list and config.list.show then
+			local show_filename = vim.list_contains(config.list.show, "filename")
+			local show_space = vim.list_contains(config.list.show, "space")
+			local show_label = vim.list_contains(config.list.show, "label")
+			local show_stick = vim.list_contains(config.list.show, "stick")
 
 			local col_offset = 0
 			-- Find where content starts (after right-alignment padding)
@@ -941,76 +945,84 @@ function M.hide()
 	state.auto_hidden = false -- Reset auto-hide state when manually hidden
 end
 
----Enter jump mode to navigate buffers by typing characters
-function M.jump()
+---Enter list mode to navigate or close buffers by typing characters
+---@param opts? {action?: "open"|"close"|fun(buffer: BufferInfo, leave: function)} Options for list mode
+function M.list(opts)
+	opts = opts or {}
+	local action = opts.action or "open"
+
 	if not state.visible then
 		M.show()
 	end
 
-	state.jump_mode = true
-	state.jump_input = ""
+	state.list_mode = true
+	state.list_input = ""
+	state.list_action = action
 
-	-- Refresh display to show characters (resize window for jump mode content)
+	-- Refresh display to show characters (resize window for list mode content)
 	create_or_update_floating_window()
 	render_buffers()
+
+	-- Helper to exit list mode
+	local function leave()
+		state.list_mode = false
+		state.list_input = ""
+		create_or_update_floating_window() -- Resize back to normal mode
+		render_buffers()
+	end
 
 	-- Start input loop
 	local function handle_input()
 		local char = vim.fn.getchar()
 		local char_str = type(char) == "number" and vim.fn.nr2char(char) or char
 
-		-- Handle escape or ctrl-c to exit jump mode
+		-- Handle escape or ctrl-c to exit list mode
 		if char == 27 or char_str == "\x03" or char_str == "\27" then
-			state.jump_mode = false
-			state.jump_input = ""
-			create_or_update_floating_window() -- Resize back to normal mode
-			render_buffers()
+			leave()
 			return
 		end
 
 		-- Handle configured close buffer key (default ctrl-q)
-		local close_key = config.jump.keys.close_buffer or "<C-q>"
+		local close_key = config.list and config.list.keys and config.list.keys.close_buffer or "<C-q>"
 		if close_key == "<C-q>" and char == 17 then -- ctrl-q
 			-- Always close the current active buffer
 			local current_buf = vim.api.nvim_get_current_buf()
 			vim.api.nvim_buf_delete(current_buf, { force = false })
-
-			state.jump_mode = false
-			state.jump_input = ""
-			create_or_update_floating_window()
-			render_buffers()
+			leave()
 			return
 		end
 
 		-- Handle regular character input
 		if char_str:match("%w") then
-			state.jump_input = state.jump_input .. char_str:lower()
+			state.list_input = state.list_input .. char_str:lower()
 
 			-- Find matching buffers
 			local buffers = get_buffer_list()
 			local matches = {}
 			for _, buffer in ipairs(buffers) do
 				-- Match against the beginning of the generated label
-				local label_prefix = buffer.label:sub(1, #state.jump_input)
-				if label_prefix == state.jump_input then
+				local label_prefix = buffer.label:sub(1, #state.list_input)
+				if label_prefix == state.list_input then
 					table.insert(matches, buffer)
 				end
 			end
 
-			-- If exactly one match, jump to it
+			-- If exactly one match, perform the action
 			if #matches == 1 then
-				vim.api.nvim_set_current_buf(matches[1].id)
-				state.jump_mode = false
-				state.jump_input = ""
-				create_or_update_floating_window() -- Resize back to normal mode
-				render_buffers()
+				if type(state.list_action) == "function" then
+					-- Custom function action
+					state.list_action(matches[1], leave)
+				elseif state.list_action == "open" then
+					vim.api.nvim_set_current_buf(matches[1].id)
+					leave()
+				elseif state.list_action == "close" then
+					vim.api.nvim_buf_delete(matches[1].id, { force = false })
+					leave()
+				end
 				return
 			elseif #matches == 0 then
-				-- No matches, exit jump mode
-				state.jump_mode = false
-				state.jump_input = ""
-				create_or_update_floating_window() -- Resize back to normal mode
-				render_buffers()
+				-- No matches, exit list mode
+				leave()
 				return
 			end
 
@@ -1018,16 +1030,23 @@ function M.jump()
 			render_buffers()
 			vim.schedule(handle_input)
 		else
-			-- Invalid character, exit jump mode
-			state.jump_mode = false
-			state.jump_input = ""
-			create_or_update_floating_window() -- Resize back to normal mode
-			render_buffers()
+			-- Invalid character, exit list mode
+			leave()
 		end
 	end
 
 	-- Start input handling with a small delay
 	vim.defer_fn(handle_input, 10)
+end
+
+---Alias for list mode with "open" action
+function M.jump()
+	M.list({ action = "open" })
+end
+
+---Alias for list mode with "close" action
+function M.close()
+	M.list({ action = "close" })
 end
 
 ---Toggle the visibility of buffer sticks
@@ -1213,7 +1232,9 @@ function M.setup(opts)
 		toggle = M.toggle,
 		show = M.show,
 		hide = M.hide,
+		list = M.list,
 		jump = M.jump,
+		close = M.close,
 	}
 end
 

--- a/lua/buffer-sticks/init.lua
+++ b/lua/buffer-sticks/init.lua
@@ -37,8 +37,12 @@ local state = {
 ---@field bottom integer Bottom padding inside the window
 ---@field left integer Left padding inside the window
 
+---@class BufferSticksJumpKeys
+---@field close_buffer string Key combination to close buffer in jump mode
+
 ---@class BufferSticksJump
 ---@field show string[] What to show in jump mode: "filename", "space", "label", "stick"
+---@field keys BufferSticksJumpKeys Key mappings for jump mode
 
 ---@class BufferSticksLabel
 ---@field show "always"|"jump"|"never" When to show buffer name characters
@@ -76,7 +80,12 @@ local config = {
 	transparent = true,
 	auto_hide = true,
 	label = { show = "jump" },
-	jump = { show = { "filename", "space", "label" } },
+	jump = {
+		show = { "filename", "space", "label" },
+		keys = {
+			close_buffer = "<C-q>",
+		},
+	},
 	highlights = {
 		active = { fg = "#bbbbbb" },
 		alternate = { fg = "#888888" },
@@ -955,6 +964,20 @@ function M.jump()
 			state.jump_mode = false
 			state.jump_input = ""
 			create_or_update_floating_window() -- Resize back to normal mode
+			render_buffers()
+			return
+		end
+
+		-- Handle configured close buffer key (default ctrl-q)
+		local close_key = config.jump.keys.close_buffer or "<C-q>"
+		if close_key == "<C-q>" and char == 17 then -- ctrl-q
+			-- Always close the current active buffer
+			local current_buf = vim.api.nvim_get_current_buf()
+			vim.api.nvim_buf_delete(current_buf, { force = false })
+
+			state.jump_mode = false
+			state.jump_input = ""
+			create_or_update_floating_window()
 			render_buffers()
 			return
 		end


### PR DESCRIPTION
- Rename jump() to list(opts) with action parameter
- Add backward-compatible jump() alias for list({ action = 'open' })
- Add close() alias for list({ action = 'close' })
- Support custom action functions: action = function(buffer, leave)
  - Enables using buffer-sticks as a customizable buffer picker
  - Custom functions receive selected buffer and leave() callback
  - User controls when to exit list mode
- Rename internal state: jump_mode → list_mode, jump_input → list_input
- Update config: jump → list, label.show = 'jump' → 'list'
- Keep Ctrl-Q to close current buffer in any list mode
- Update README with list mode documentation and buffer picker examples
- Add 'Custom action functions for building buffer pickers' to features