### PR TITLE
chore(docs): update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,26 @@ return {
 			function()
 				BufferSticks.jump()
 			end,
-			desc = "Buffer jump mode",
+			desc = "Jump to buffer",
+		},
+		{
+			"<leader>q",
+			function()
+				BufferSticks.close()
+			end,
+			desc = "Close buffer",
+		},
+		{
+			"<leader>p",
+			function()
+				BufferSticks.list({
+					action = function(buffer, leave)
+						print("Selected: " .. buffer.name)
+						leave()
+					end
+				})
+			end,
+			desc = "Buffer picker",
 		},
 	},
 	config = function()


### PR DESCRIPTION
- Add three keymapping examples in Quick Setup section:
  - <leader>j for jump to buffer
  - <leader>q for close buffer
  - <leader>p for custom buffer picker example
- Demonstrates all three list mode usage patterns