### PR TITLE
feat: add `is_visible`

### DIFF
--- a/lua/buffer-sticks/init.lua
+++ b/lua/buffer-sticks/init.lua
@@ -2086,5 +2086,11 @@ function M.setup(opts)
 	}
 end
 
+---Check if the buffer list is visible
+---@return boolean Whether the buffer list is visible
+function M.is_visible()
+	return state.visible
+end
+
 return M
 -- vim:noet:ts=4:sts=4:sw=4:


### PR DESCRIPTION
Add a simple `is_visible` function to access `state.visible` with `require("buffer-sticks").is_visible()` from outside.