### PR TITLE
feat(preview): display buffer filename in float title by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ require("buffer-sticks").setup({
       width = 0.5,                     -- Width as fraction of screen (0.0 to 1.0)
       height = 0.8,                    -- Height as fraction of screen (0.0 to 1.0)
       border = "single",               -- Border style: "none", "single", "double", "rounded", "solid", "shadow"
-      title = nil,                     -- Window title (string or nil)
+      title = nil,                     -- Window title: nil/true = filename, false = no title, "string" = custom (default: nil/filename)
       title_pos = "center",            -- Title position: "left", "center", "right"
       footer = nil,                    -- Window footer (string or nil)
       footer_pos = "center",           -- Footer position: "left", "center", "right"
@@ -282,7 +282,7 @@ Buffer preview shows the content of the selected buffer while navigating in list
   - Configurable position: `"right"`, `"left"`, or `"below"`
   - Configurable size as fraction of screen
   - Customizable border, title, and footer
-  - Default: right side, 50% width, 80% height, single border
+  - Default: right side, 50% width, 80% height, single border, filename as title
 
 - **`"current"`** - Switches buffer in the current window
   - Shows immediate preview as you navigate
@@ -304,13 +304,18 @@ preview = {
     width = 0.5,         -- 0.0 to 1.0 (fraction of screen)
     height = 0.8,        -- 0.0 to 1.0 (fraction of screen)
     border = "rounded",  -- "none", "single", "double", "rounded", "solid", "shadow"
-    title = "Preview",   -- Window title (optional)
+    title = nil,         -- nil/true = show filename (default), false = no title, "string" = custom title
     title_pos = "center", -- "left", "center", "right"
     footer = nil,        -- Window footer (optional)
     footer_pos = "center", -- "left", "center", "right"
   },
 }
 ```
+
+**Title options:**
+- `title = nil` or `title = true` - Shows the buffer filename (default behavior)
+- `title = false` - No title displayed
+- `title = " Custom "` - Shows custom text
 
 ### Highlight Options
 

--- a/lua/buffer-sticks/init.lua
+++ b/lua/buffer-sticks/init.lua
@@ -199,6 +199,21 @@ local state = {
 ---@field buftypes? string[] List of buftypes to exclude from buffer sticks (e.g., "terminal", "help", "quickfix")
 ---@field names? string[] List of buffer name patterns to exclude (supports lua patterns)
 
+---@class BufferSticksPreviewFloat
+---@field position? "left"|"right"|"below" Position of the preview window (default: "right")
+---@field width? number Width as fraction of screen (default: 0.5)
+---@field height? number Height as fraction of screen (default: 0.8)
+---@field border? string Border style (default: "single")
+---@field title? string|boolean Title text: nil/true = filename, false = no title, string = custom text (default: nil/filename)
+---@field title_pos? "left"|"center"|"right" Title position (default: "center")
+---@field footer? string Footer text (default: nil)
+---@field footer_pos? "left"|"center"|"right" Footer position (default: "center")
+
+---@class BufferSticksPreview
+---@field enabled? boolean Whether preview is enabled (default: true)
+---@field mode? "float"|"current"|"last_window" Preview mode (default: "float")
+---@field float? BufferSticksPreviewFloat Float window configuration
+
 ---@class BufferSticksConfig
 ---@field offset BufferSticksOffset Position offset for fine-tuning
 ---@field padding BufferSticksPadding Padding inside the window
@@ -214,6 +229,7 @@ local state = {
 ---@field label? BufferSticksLabel Label display configuration
 ---@field list? BufferSticksList List mode configuration
 ---@field filter? BufferSticksFilter Filter configuration for excluding buffers
+---@field preview? BufferSticksPreview Preview configuration
 ---@field highlights table<string, BufferSticksHighlights> Highlight groups for active/inactive/label states
 local config = {
 	offset = { x = 0, y = 0 },
@@ -1336,8 +1352,17 @@ local function create_preview_float(buffer_id)
 		zindex = 9,
 	}
 
-	if preview_config.title then
-		win_config.title = preview_config.title
+	-- Handle title configuration: nil/true = filename, false = no title, string = custom
+	if preview_config.title ~= false then
+		local title_text
+		if type(preview_config.title) == "string" then
+			title_text = preview_config.title
+		else
+			-- Default: show filename
+			local buf_name = vim.api.nvim_buf_get_name(buffer_id)
+			title_text = buf_name ~= "" and vim.fn.fnamemodify(buf_name, ":t") or "[No Name]"
+		end
+		win_config.title = " " .. title_text .. " "
 		win_config.title_pos = preview_config.title_pos or "center"
 	end
 


### PR DESCRIPTION
Float preview windows now show the buffer filename in the title bar, improving context during navigation. Configurable via title option: nil/true shows filename, false hides title, string sets custom text. Unnamed buffers display "[No Name]".

<img width="2496" height="2010" alt="image" src="https://github.com/user-attachments/assets/9643199a-2b4b-42a8-8489-659e618d8019" />
