### PR TITLE
fix: filter terminal buffers by name pattern for session-restored buffers

### DIFF
--- a/lua/buffer-sticks/buffers.lua
+++ b/lua/buffer-sticks/buffers.lua
@@ -162,6 +162,11 @@ function M.get_buffer_list()
 						should_include = false
 						break
 					end
+					-- Fallback: detect terminal by name pattern (for unloaded session-restored buffers)
+					if bt == "terminal" and buf_name:match("^term://") then
+						should_include = false
+						break
+					end
 				end
 			end
 


### PR DESCRIPTION
Unloaded buffers from session restore have empty buftype until entered. Fall back to `term://` name pattern when filtering terminal buftypes.