### PR TITLE
feat(list): add configurable confirm and backspace keys

### DIFF
--- a/lua/buffer-sticks/config.lua
+++ b/lua/buffer-sticks/config.lua
@@ -17,11 +17,13 @@
 ---@field close_buffer string Key combination to close buffer in list mode
 ---@field move_up string Key to move selection up in list mode
 ---@field move_down string Key to move selection down in list mode
+---@field confirm string Key to confirm selection in list mode
 
 ---@class BufferSticksFilterKeys
 ---@field enter string Key to enter filter mode
 ---@field confirm string Key to confirm selection in filter mode
 ---@field exit string Key to exit filter mode
+---@field backspace string Key to delete character in filter mode
 ---@field move_up string Key to move selection up in filter mode
 ---@field move_down string Key to move selection down in filter mode
 
@@ -100,6 +102,7 @@ local M = {
 			close_buffer = "<C-q>",
 			move_up = "<Up>",
 			move_down = "<Down>",
+			confirm = "<CR>",
 		},
 		filter = {
 			title = "➜ ",
@@ -110,6 +113,7 @@ local M = {
 				enter = "/",
 				confirm = "<CR>",
 				exit = "<Esc>",
+				backspace = "<BS>",
 				move_up = "<Up>",
 				move_down = "<Down>",
 			},

--- a/lua/buffer-sticks/list.lua
+++ b/lua/buffer-sticks/list.lua
@@ -136,7 +136,8 @@ local function handle_filter_input(char, char_str, handle_input)
 	end
 
 	-- Backspace
-	if char == 127 or char == 8 or char_str == "<80>kb" or char_str:match("kb$") then
+	local backspace_key = filter_keys.backspace or "<BS>"
+	if matches_key(char, char_str, backspace_key) then
 		if #state.filter_input > 0 then
 			state.filter_input = state.filter_input:sub(1, -2)
 			state.filter_selected_index = 1
@@ -227,7 +228,8 @@ function M.enter(opts, show_fn)
 		end
 
 		-- Escape or ctrl-c
-		if char == 27 or (type(char_str) == "string" and (char_str == "\x03" or char_str == "\27")) then
+		local exit_key = config.list and config.list.filter and config.list.filter.keys and config.list.filter.keys.exit or "<Esc>"
+		if matches_key(char, char_str, exit_key) or matches_key(char, char_str, "<C-c>") then
 			if state.filter_mode then
 				state.filter_mode = false
 				state.filter_input = ""
@@ -301,7 +303,8 @@ function M.enter(opts, show_fn)
 		end
 
 		-- Enter to confirm selection
-		if (char == 13 or char == 10) and state.list_mode_selected_index ~= nil then
+		local confirm_key = list_keys.confirm or "<CR>"
+		if matches_key(char, char_str, confirm_key) and state.list_mode_selected_index ~= nil then
 			local buf_list = buffers_mod.get_buffer_list()
 			if state.list_mode_selected_index > 0 and state.list_mode_selected_index <= #buf_list then
 				local selected_buffer = buf_list[state.list_mode_selected_index]


### PR DESCRIPTION
This pull request enhances the configurability of key bindings in the buffer-sticks plugin by allowing users to customize the confirm and backspace keys in both list and filter modes. It also refactors the key handling logic to use these new configurable keys, improving flexibility and consistency.

**Configurable key bindings:**

* Added a `confirm` key option to the `BufferSticksListKeys` and `BufferSticksFilterKeys` configurations, allowing users to specify which key confirms a selection in list and filter modes (`config.lua`). [[1]](diffhunk://#diff-1013fa3a8cc2aa618d8563f6a2c88d2f5ba92cd63cdd01e003dadccb810dca42R20-R26) [[2]](diffhunk://#diff-1013fa3a8cc2aa618d8563f6a2c88d2f5ba92cd63cdd01e003dadccb810dca42R105)
* Added a `backspace` key option to `BufferSticksFilterKeys`, letting users customize which key deletes a character in filter mode (`config.lua`). [[1]](diffhunk://#diff-1013fa3a8cc2aa618d8563f6a2c88d2f5ba92cd63cdd01e003dadccb810dca42R20-R26) [[2]](diffhunk://#diff-1013fa3a8cc2aa618d8563f6a2c88d2f5ba92cd63cdd01e003dadccb810dca42R116)

**Key handling logic improvements:**

* Updated filter input handling to use the configurable `backspace` key rather than hardcoded values (`list.lua`).
* Modified exit (escape) handling in filter mode to use the configurable `exit` key from the configuration, improving consistency (`list.lua`).
* Changed selection confirmation in list mode to use the configurable `confirm` key instead of hardcoded enter key codes (`list.lua`).