### PR TITLE
feat: `show_by_default` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ return {
 
 ```lua
 require("buffer-sticks").setup({
+  show_by_default = true,       -- Whether to show buffer-sticks by default i.e automatically calls `BufferSticks.show()`
   show_indicators = true,       -- Whether to show stick indicators
   offset = { x = 0, y = 0 },    -- Position offset (positive moves inward from right edge)
   position = "right",           -- List window position: "right" or "center"

--- a/lua/buffer-sticks/config.lua
+++ b/lua/buffer-sticks/config.lua
@@ -64,6 +64,7 @@
 ---@field float? BufferSticksPreviewFloat Float window configuration
 
 ---@class BufferSticksConfig
+---@field show_by_default boolean show buffer-sticks by default (No need to called BufferSticks.show())
 ---@field show_indicators boolean show indicators unless explicitly disabled
 ---@field offset BufferSticksOffset Position offset for fine-tuning
 ---@field padding BufferSticksPadding Padding inside the window
@@ -87,6 +88,7 @@
 
 ---@type BufferSticksConfig
 local M = {
+  show_by_default = true,
 	show_indicators = true,
 	offset = { x = 0, y = 0 },
 	padding = { top = 0, right = 1, bottom = 0, left = 1 },

--- a/lua/buffer-sticks/init.lua
+++ b/lua/buffer-sticks/init.lua
@@ -116,6 +116,8 @@ function M.setup(opts)
 				state.last_selected_buffer_id = nil
 			end
 
+      state.visible = config.show_by_default;
+
 			if state.visible then
 				M.show()
 			end


### PR DESCRIPTION
This option would innately show the buffer-sticks window without needing to call `BufferSticks.show()`, this also allows configuration to remain purely in the `opts` key for `lazy.nvim` configurations.