### PR TITLE
feat: Allow Footer to support filename

### DIFF
--- a/lua/buffer-sticks/config.lua
+++ b/lua/buffer-sticks/config.lua
@@ -55,7 +55,7 @@
 ---@field border? string Border style (default: "single")
 ---@field title? string|boolean Title: nil/true = filename, false = none, string = custom
 ---@field title_pos? "left"|"center"|"right" Title position (default: "center")
----@field footer? string Footer text (default: nil)
+---@field footer? string|"filename" Footer: "filename" = filename, string = custom
 ---@field footer_pos? "left"|"center"|"right" Footer position (default: "center")
 
 ---@class BufferSticksPreview

--- a/lua/buffer-sticks/preview.lua
+++ b/lua/buffer-sticks/preview.lua
@@ -61,7 +61,12 @@ function M.create_float(buffer_id)
 	end
 
 	if preview_config.footer then
-		win_config.footer = preview_config.footer
+		local title_text = preview_config.footer
+		if preview_config.footer == "filename" then
+			local buf_name = vim.api.nvim_buf_get_name(buffer_id)
+			title_text = buf_name ~= "" and vim.fn.fnamemodify(buf_name, ":t") or "[No Name]"
+		end
+		win_config.footer = " " .. title_text .. " "
 		win_config.footer_pos = preview_config.footer_pos or "center"
 	end
 


### PR DESCRIPTION
Simple config change to allow `preview.float.footer` to display a filename if it supplied with the value `filename`.