### PR TITLE
Fix: Accidental regression of #69

### DIFF
--- a/lua/buffer-sticks/config.lua
+++ b/lua/buffer-sticks/config.lua
@@ -64,6 +64,7 @@
 ---@field float? BufferSticksPreviewFloat Float window configuration
 
 ---@class BufferSticksConfig
+---@field show_by_default boolean show buffer-sticks by default (No need to called BufferSticks.show())
 ---@field show_indicators boolean show indicators unless explicitly disabled
 ---@field offset BufferSticksOffset Position offset for fine-tuning
 ---@field padding BufferSticksPadding Padding inside the window
@@ -87,6 +88,7 @@
 
 ---@type BufferSticksConfig
 local M = {
+	show_by_default = true,
 	show_indicators = true,
 	offset = { x = 0, y = 0 },
 	padding = { top = 0, right = 1, bottom = 0, left = 1 },

--- a/lua/buffer-sticks/init.lua
+++ b/lua/buffer-sticks/init.lua
@@ -116,6 +116,8 @@ function M.setup(opts)
 				state.last_selected_buffer_id = nil
 			end
 
+			state.visible = config.show_by_default
+
 			if state.visible then
 				M.show()
 			end


### PR DESCRIPTION
Due to my commit on #70 where I had accidentally commented the same changes as done in #69 it resulted in a loss of functionality when #70 was merged after #69. This puts the `show_by_default` option back in place. My apologies for the regression!